### PR TITLE
New Strategy options

### DIFF
--- a/lib/passport-ldap/strategy.js
+++ b/lib/passport-ldap/strategy.js
@@ -51,7 +51,11 @@ function Strategy(options, verify) {
       base: '',
       search: {
         filter: ''
-      }
+      },
+      authOnly: false,
+      authMode: 1,        // 0 win, 1 Unix (linux, Solaris, ...)
+      uidTag: 'uid',       // Linux OpenLDAP 'uid', Sun Solaris 'cn'
+      debug: false
     };
   }
   if (!verify) throw new Error('LDAP authentication strategy requires a verify function');
@@ -71,6 +75,10 @@ util.inherits(Strategy, passport.Strategy);
 
 /**
  * Authenticate request by binding to LDAP server, and then searching for the user entry.
+ * 
+ * Command line LDAP bind and search examples:
+ * - Windows with Active Directory: ldapsearch -H ldap://192.168.1.17:389 -D XXX -w YYY -b dc=example,dc=local objectclass=*
+ * - Linux/Sun Solaris with OpenLDAP: ldapsearch -H ldap://192.168.1.16:389 -D cn=XXX,dc=cybrain,dc=local -w YYY -b dc=example,dc=local objectclass=*
  *
  * @param {Object} req
  * @api protected
@@ -82,30 +90,58 @@ Strategy.prototype.authenticate = function(req, options) {
     return self.fail(401);
   }
 
-  self.client.bind(req.body.user, req.body.pwd, function(err) {
+  var user = req.body.user;
+  if (self._options.authMode === 1) {
+    user = self._options.uidTag + '=' + req.body.user + ',' + self._options.base;
+  }
+  self.client.bind(user, req.body.pwd, function(err) {
     if (err) {
+      if (self._options.debug) console.log('(EE) [ldapjs] LDAP error:', err);
       return self.fail(403);
     }
+    
+    if (self._options.authOnly) {
+      if (self._options.debug) console.log('(II) [ldapjs] auth success:', req.body.user);
+      self.success({uid: req.body.user});
+    } else {
+      self._options.search.filter = self._options.search.filter.replace(/\$uid\$/, req.body.user);
+      self.client.search(self._options.base, self._options.search, function(err, res) {
+        if (err) {
+          if (self._options.debug) console.log('(EE) [ldapjs] LDAP error:', err);
+          return self.fail(403);
+        }
+        
+        res.on('searchEntry', function(entry) {
+          var profile = JSON.stringify(entry.object);
 
-    self.client.search(self._options.base, self._options.search, function(err, res) {
-      if (err) {
-        return self.fail(403);
-      }
-
-      res.on('searchEntry', function(entry) {
-        var profile = JSON.stringify(entry.object);
-
-        self._verify(profile, function(err, user) {
-          if (err) {
-            return self.error(err);
+          self._verify(profile, function(err, user) {
+            if (err) {
+              if (self._options.debug) console.log('(EE) [ldapjs] LDAP error:', err);
+              return self.error(err);
+            }
+            if (!user) {
+              if (self._options.debug) console.log('(EE) [ldapjs] LDAP user error:', self._challenge());
+              return self.fail(self._challenge());
+            }
+            if (self._options.debug) console.log('(II) [ldapjs] auth success:', user);
+            self.success(user);
+          });
+        });
+        
+        res.on('error', function(err) {
+          if (self._options.debug) console.log('(EE) [ldapjs] Network error:', err);
+          self.error(err);
+        });
+        
+        res.on('end', function(result) {
+          if (result.status !== 0) {
+            if (self._options.debug) console.log('(EE) [ldapjs] Result not OK:', result);
+            self.fail(result.status);
           }
-          if (!user) {
-            return self.fail(self._challenge());
-          }
-          self.success(user);
         });
       });
-    });
+    }
+
   });
 };
 
@@ -113,3 +149,4 @@ Strategy.prototype.authenticate = function(req, options) {
  * Expose `Strategy`.
  */
 module.exports = Strategy;
+

--- a/lib/passport-ldap/strategy.js
+++ b/lib/passport-ldap/strategy.js
@@ -78,7 +78,7 @@ util.inherits(Strategy, passport.Strategy);
  * 
  * Command line LDAP bind and search examples:
  * - Windows with Active Directory: ldapsearch -H ldap://192.168.1.17:389 -D XXX -w YYY -b dc=example,dc=local objectclass=*
- * - Linux/Sun Solaris with OpenLDAP: ldapsearch -H ldap://192.168.1.16:389 -D cn=XXX,dc=cybrain,dc=local -w YYY -b dc=example,dc=local objectclass=*
+ * - Linux/Sun Solaris with OpenLDAP: ldapsearch -H ldap://192.168.1.16:389 -D cn=XXX,dc=example,dc=local -w YYY -b dc=example,dc=local objectclass=*
  *
  * @param {Object} req
  * @api protected
@@ -96,7 +96,7 @@ Strategy.prototype.authenticate = function(req, options) {
   }
   self.client.bind(user, req.body.pwd, function(err) {
     if (err) {
-      if (self._options.debug) console.log('(EE) [ldapjs] LDAP error:', err);
+      if (self._options.debug) console.log('(EE) [ldapjs] LDAP error:', err.stack);
       return self.fail(403);
     }
     
@@ -104,19 +104,20 @@ Strategy.prototype.authenticate = function(req, options) {
       if (self._options.debug) console.log('(II) [ldapjs] auth success:', req.body.user);
       self.success({uid: req.body.user});
     } else {
+      var dn = (self._options.authMode === 1 ? user : self._options.base);
       self._options.search.filter = self._options.search.filter.replace(/\$uid\$/, req.body.user);
-      self.client.search(self._options.base, self._options.search, function(err, res) {
+      self.client.search(dn, self._options.search, function(err, res) {
         if (err) {
-          if (self._options.debug) console.log('(EE) [ldapjs] LDAP error:', err);
+          if (self._options.debug) console.log('(EE) [ldapjs] LDAP error:', err.stack);
           return self.fail(403);
         }
         
         res.on('searchEntry', function(entry) {
-          var profile = JSON.stringify(entry.object);
+          var profile = entry.object;
 
           self._verify(profile, function(err, user) {
             if (err) {
-              if (self._options.debug) console.log('(EE) [ldapjs] LDAP error:', err);
+              if (self._options.debug) console.log('(EE) [ldapjs] LDAP error:', err.stack);
               return self.error(err);
             }
             if (!user) {
@@ -129,7 +130,7 @@ Strategy.prototype.authenticate = function(req, options) {
         });
         
         res.on('error', function(err) {
-          if (self._options.debug) console.log('(EE) [ldapjs] Network error:', err);
+          if (self._options.debug) console.log('(EE) [ldapjs] Network error:', err.stack);
           self.error(err);
         });
         


### PR DESCRIPTION
This pull request should increase the compatibility of the Strategy with different LDAP servers (i.e.: Windows Active Directory, OpenLDAP on Linux/Sun Solaris).
- Options added to Strategy creation:
  - authOnly: if true only the bind against the LDAP is done, otherwise also the search will be executed.
  - authMode: 0 for the Windows AD user definition (user name only), 1 for the OpenLDAP user definition (complete DN: user id + base DN).
  - uidTag: string representing the user id tag in the complete DN used as a user with authMode 1.
  - debug: if set to true, debug informations are printed to cmd (very usefull when interfacing new LDAP servers ;) ).
- Modified the code for Strategy accordingly to the added options.
- When defining a filter for the search, if the string '$uid$' is used inside the filter string, it will be replaced by the user id given for the authentication - i.e. we can use as a filter '(uid=$uid$)', which for instance will be translated in '(uid=user1)'.
- Added command line examples to access win\* and *nix LDAP servers.

Regards,
Matteo
