### PR TITLE
patch package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "./lib/passport-ldap",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "ldapjs": "0.6.2"
+    "ldapjs": "0.6.3"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
dtrace-provider need recent version.
this library has dependency ladpjs.

so ldapjs need recent version.

Thanks^^
