### PR TITLE
Fix connection timeout error, add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ application:
 
 ## Examples
 
-For a complete, working example, refer to the [login example](https://github.com/mintbridge/passport-ldap/tree/master/examples/login).
+For a complete, working example, refer to the [passport example](/example.js).
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ given ldap server using the openldap protocol.
 The strategy requires a `verify` callback which accepts a user `profile` entry
 from the directory, and then calls the `done` callback supplying a `user`.
 
+```javascript
     passport.use(new LDAPStrategy({
         server: {
           url: 'ldap://0.0.0.0:1389'
@@ -36,7 +37,7 @@ from the directory, and then calls the `done` callback supplying a `user`.
         return done(null, JSON.parse(profile));
       }
     ));
-
+```
 #### Authenticate Requests
 
 Use `passport.authenticate()`, specifying the `'ldap'` strategy, to
@@ -44,7 +45,7 @@ authenticate requests.
 
 For example, as route middleware in an [Express](http://expressjs.com/)
 application:
-
+```javascript
     app.get('/auth/login',
       passport.authenticate('facebook'));
 
@@ -54,12 +55,24 @@ application:
         failureRedirect: '/auth/login/'
       })
     );
-
+```
 #### Profile Fields
+
+| Option | Type | Default | Description |
+| ------------- | ------------- | ------------- | ------------- |
+| `server` | `Object` | `{url:''}` | Set the server URL in the format of `{url:'url.com:port'}` |
+| `usernameField` | `String` | `'user'` | Set the field to use for the `username` from the request sent |
+| `passwordField` | `String` | `'pwd'` | Set the field to use for the `password` from the request sent |
+| `base` | `String|Array` | `''` | Base DN to search against |
+| `search` | `Object` | `{filter:''}` | Object containing search options |
+| `authOnly` | `Boolean` | `false` | Whether to only get a successfull authentication with the server without returning the LDAP user |
+| `authMode` | `Number` | `1` | Used to differentiate between a Windows `0` or Unix LDAP server `1` |
+| `uidTag` | `String` | `uid` | Linux OpenLDAP `uid`, Sun Solaris `cn` |
+| `debug` | `Boolean` | `false` | Enable/disable debug messages |
 
 ## Examples
 
-For a complete, working example, refer to the [passport example](/example.js).
+For a complete working example refer to the [passport example](/example.js).
 
 ## Tests
 

--- a/example.js
+++ b/example.js
@@ -1,0 +1,46 @@
+var express = require('express');
+var session = require('express-session');
+var LDAPStrategy = require('passport-lap').Strategy;
+
+// Windows LDAP
+var ldapConfig = {
+    server: {
+        url: 'ldap://some.server.url.com:9999'
+    },
+    authMode: 0,
+    debug: false,
+    usernameField: 'username',
+    passwordField: 'password',
+    base: ['dc=ad','dc=sm','dc=else'],
+    search: {
+        filter: '(sAMAccountName=$uid$)',
+        scope: 'sub',
+        attributes: ['list','of','user','attributes','you','want','returned'],
+        sizeLimit: 1
+    },
+    searchAttributes: ['displayName']
+};
+
+module.exports = function(app,passport){
+  app.use(session({
+      secret: 'anawesomesecret'
+  }));
+
+  passport.use(new LDAPStrategy(
+      ldapConfig,
+      function(profile, done) {
+          return done(null, profile);
+      }
+  ));
+
+  passport.serializeUser(function(user,done){
+      done(null,user);
+  });
+
+  passport.deserializeUser(function(user,done){
+      done(null,user);
+  });
+
+  app.use(passport.initialize());
+  app.use(passport.session());
+};

--- a/lib/passport-ldap/strategy.js
+++ b/lib/passport-ldap/strategy.js
@@ -97,7 +97,11 @@ Strategy.prototype.authenticate = function(req, options) {
   var username = req.body[self._options.usernameField];
 
   if (self._options.authMode === 1) {
-    username = self._options.uidTag + '=' + username + ',' + self._options.base;
+    var base = self._options.base;
+    if(typeof base !== 'string'){
+      base = base.join(',');
+    }
+    username = self._options.uidTag + '=' + username + ',' + base;
   }
 
   Client.bind(username, req.body[self._options.passwordField], function (err) {

--- a/lib/passport-ldap/strategy.js
+++ b/lib/passport-ldap/strategy.js
@@ -48,6 +48,8 @@ function Strategy(options, verify) {
       server: {
         url : ''
       },
+      usernameField: 'user',
+      passwordField: 'pwd',
       base: '',
       search: {
         filter: ''
@@ -63,7 +65,6 @@ function Strategy(options, verify) {
   passport.Strategy.call(this);
 
   this.name = 'ldap';
-  this.client = ldap.createClient(options.server);
   this._verify = verify;
   this._options = options;
 }
@@ -81,37 +82,61 @@ util.inherits(Strategy, passport.Strategy);
  * - Linux/Sun Solaris with OpenLDAP: ldapsearch -H ldap://192.168.1.16:389 -D cn=XXX,dc=example,dc=local -w YYY -b dc=example,dc=local objectclass=*
  *
  * @param {Object} req
+ * @param {Object} options
  * @api protected
  */
 Strategy.prototype.authenticate = function(req, options) {
   var self = this;
+  // Create the client on every auth attempt the LDAP server can close the connection
+  var Client = ldap.createClient(self._options.server);
 
-  if (!req.body.user || !req.body.pwd) {
+  if (!req.body || !req.body[self._options.usernameField] || !req.body[self._options.passwordField]) {
     return self.fail(401);
   }
 
-  var user = req.body.user;
+  var username = req.body[self._options.usernameField];
+
   if (self._options.authMode === 1) {
-    user = self._options.uidTag + '=' + req.body.user + ',' + self._options.base;
+    user = self._options.uidTag + '=' + username + ',' + self._options.base;
   }
-  self.client.bind(user, req.body.pwd, function(err) {
+
+  Client.bind(username, req.body[self._options.passwordField], function (err) {
     if (err) {
       if (self._options.debug) console.log('(EE) [ldapjs] LDAP error:', err.stack);
       return self.fail(403);
     }
-    
+
     if (self._options.authOnly) {
-      if (self._options.debug) console.log('(II) [ldapjs] auth success:', req.body.user);
-      self.success({uid: req.body.user});
+      if (self._options.debug) console.log('(II) [ldapjs] auth success:', username);
+      self.success({
+        uid: username
+      });
     } else {
-      var dn = (self._options.authMode === 1 ? user : self._options.base);
-      self._options.search.filter = self._options.search.filter.replace(/\$uid\$/, req.body.user);
-      self.client.search(dn, self._options.search, function(err, res) {
+      var dn = username;
+      if (self._options.authMode !== 1) {
+        // Add the dc from the username if not already in the configuration
+        var nameSplit = username.split('\\');
+        var name = nameSplit[1];
+        var dc = 'dc=' + nameSplit[0].toLowerCase();
+
+        dn = self._options.base.slice();
+        if (self._options.base.indexOf(dc) === -1) {
+          dn.splice(0, 0, dc);
+        }
+        dn = dn.join(',');
+      }
+
+      // Create copy of the search object so we don't overwrite it
+      var search = Object.create(self._options.search);
+
+      // Replace placeholder name
+      search.filter = search.filter.replace(/\$uid\$/, name);
+      Client.search(dn, search, function (err, res) {
         if (err) {
           if (self._options.debug) console.log('(EE) [ldapjs] LDAP error:', err.stack);
           return self.fail(403);
         }
-        
+    
         res.on('searchEntry', function(entry) {
           var profile = entry.object;
 
@@ -128,12 +153,12 @@ Strategy.prototype.authenticate = function(req, options) {
             self.success(user);
           });
         });
-        
+
         res.on('error', function(err) {
           if (self._options.debug) console.log('(EE) [ldapjs] Network error:', err.stack);
           self.error(err);
         });
-        
+
         res.on('end', function(result) {
           if (result.status !== 0) {
             if (self._options.debug) console.log('(EE) [ldapjs] Result not OK:', result);
@@ -150,4 +175,3 @@ Strategy.prototype.authenticate = function(req, options) {
  * Expose `Strategy`.
  */
 module.exports = Strategy;
-

--- a/lib/passport-ldap/strategy.js
+++ b/lib/passport-ldap/strategy.js
@@ -97,7 +97,7 @@ Strategy.prototype.authenticate = function(req, options) {
   var username = req.body[self._options.usernameField];
 
   if (self._options.authMode === 1) {
-    user = self._options.uidTag + '=' + username + ',' + self._options.base;
+    username = self._options.uidTag + '=' + username + ',' + self._options.base;
   }
 
   Client.bind(username, req.body[self._options.passwordField], function (err) {
@@ -115,15 +115,19 @@ Strategy.prototype.authenticate = function(req, options) {
       var dn = username;
       if (self._options.authMode !== 1) {
         // Add the dc from the username if not already in the configuration
-        var nameSplit = username.split('\\');
-        var name = nameSplit[1];
-        var dc = 'dc=' + nameSplit[0].toLowerCase();
-
-        dn = self._options.base.slice();
-        if (self._options.base.indexOf(dc) === -1) {
-          dn.splice(0, 0, dc);
+        if(typeof self._options.base !== 'string'){
+          var nameSplit = username.split('\\');
+          var name = nameSplit[1];
+          var dc = 'dc=' + nameSplit[0].toLowerCase();
+  
+          dn = self._options.base.slice();
+          if (self._options.base.indexOf(dc) === -1) {
+            dn.splice(0, 0, dc);
+          }
+          dn = dn.join(',');
+        } else {
+          dn = self._options.base;
         }
-        dn = dn.join(',');
       }
 
       // Create copy of the search object so we don't overwrite it

--- a/package.json
+++ b/package.json
@@ -1,12 +1,29 @@
 {
   "name": "passport-ldap",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "description": "LDAP authentication strategy for Passport.",
   "author": {
     "name": "Paul Dixon",
     "email": "paul.dixon@mintbridge.co.uk",
     "url": "http://www.mintbridge.co.uk/"
   },
+  "contributors": [
+    {
+      "name":"Matteo Brunati"
+    },
+    {
+      "name":"Jongwook Park",
+      "email":"niceilm@naver.com"
+    }
+    {
+      "name":"Paul Dixon",
+      "email":"paul.dixon@mintbridge.co.uk"
+    }
+    {
+      "name": "Enzo Martin",
+      "email": "enzo.martin@dice.se"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/mintbridge/passport-ldap.git"


### PR DESCRIPTION
This fixes an issue where the LDAP connection can timeout/get closed by the LDAP server due to idle time which will break the Strategy from working unless the application is restarted.

Adds the ability to configure the username/password field to use from the request, and adds support for replacing the placeholder string in the configured filter. (#7)

I've also added a Windows LDAP example. (#4)

Tested with a Windows AD server
